### PR TITLE
fix: hover broken on firefox 133

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If your sidebar is on the right side of the screen, the visual changes might not
 Some other Sidebery settings improve the experience when the sidebar is collapsed:
 
 - "Context menu" -> "Use native context menu" allows the menu to escape the bounds of the sidebar. Keeps the context menu open even when the sidebar collapses.
-- "Shot titles of pinned tabs" makes pinned tabs stack vertically instead of horizontally. This keeps all pinned tabs visible.
+- "Show titles of pinned tabs" makes pinned tabs stack vertically instead of horizontally. This keeps all pinned tabs visible.
 - "Navigation bar" -> "Enabled elements" and remove "Create tabs panel" to see your current panel. Note that you can still create new panels easily by right-clicking a tab -> "Move to" -> "New panel".
 
 ## Usage

--- a/chrome/user-hover-sidebar.css
+++ b/chrome/user-hover-sidebar.css
@@ -18,7 +18,7 @@ from https://www.reddit.com/r/FirefoxCSS/comments/yx99mj/autohide_sidebar_css_st
   min-width: var(--sidebar-min) !important;
   max-width: var(--sidebar-min) !important;
   border-right: 1px solid var(--sidebar-border-color);
-  z-index: 1;
+  z-index: 3;
   transition: all var(--hover-speed);
   transition-delay: 0;
 }


### PR DESCRIPTION
Previously, the sidebar would extend out from the side and underlap the main content.

With this change, the sidebar now overlaps the main page which is the intended behavior.

Also fixed a spelling error.